### PR TITLE
Reuse default SQL buffer it there is one

### DIFF
--- a/ob-sql-mode.el
+++ b/ob-sql-mode.el
@@ -5,7 +5,7 @@
 ;; Author: Nik Clayton nik@google.com
 ;; URL: http://github.com/nikclayton/ob-sql-mode
 ;; Version: 1.0
-;; Package-Requires: ((emacs "24.3"))
+;; Package-Requires: ((emacs "24.4"))
 ;; Keywords: languages, org, org-babel, sql
 
 ;; This file is part of GNU Emacs.
@@ -139,6 +139,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'subr-x)
 (require 'ob)
 (require 'org)
 (require 'sql)
@@ -185,14 +186,13 @@ parameters to the code block.")
          (statements
           (mapcar (lambda (c) (format "%s;" c))
                   (split-string
-                   (replace-regexp-in-string
-                    "[[:space:]\n\r]+\\'" ""
+                   (string-trim-right
                     ;; Replace newlines with spaces
                     (replace-regexp-in-string
                      "\n" " "
                      ;; Remove comments, as the query is going to be
                      ;; flattened to one line.
-                     (replace-regexp-in-string " --.*\n" "" body)))
+                     (replace-regexp-in-string "^[[:space:]]*--.*$" "" body)))
                    ";" t "[[:space:]\r\n]+"))))
     (with-temp-buffer
       (let ((adjusted-statements (run-hook-with-args-until-success

--- a/ob-sql-mode.el
+++ b/ob-sql-mode.el
@@ -200,6 +200,7 @@ parameters to the code block.")
                                   statements processed-params)))
         (when adjusted-statements
           (setq statements adjusted-statements)))
+      (setq statements (string-join statements))
       (sql-redirect session statements (buffer-name) nil)
       (run-hooks 'org-babel-sql-mode-post-execute-hook)
       (buffer-string))))


### PR DESCRIPTION
Add support for reuse `*SQL*` buffer when there is no a `:product` defined, else prompt for a product.