### PR TITLE
fix header with missing ':' for block level properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ a properties drawer to the heading with the following syntax:
 ``` org
 ** TODO Perform some queries to investigate some data
 :PROPERTIES:
-:header-args:sql-mode :product sqlite
-:header-args:sql-mode+ :session session-name
+:header-args:sql-mode: :product sqlite
+:header-args:sql-mode+: :session session-name
 :END:
 
 #+BEGIN_SRC sql-mode


### PR DESCRIPTION
From the docs at https://orgmode.org/manual/Using-Header-Arguments.html

Language-specific header arguments are also read from properties ‘header-args:<LANG>’ where <LANG> is the language identifier. For example,

* Heading :PROPERTIES:
  :header-args:clojure:    :session *clojure-1*
  :header-args:R:          :session *R*
  :END:
** Subheading
  :PROPERTIES:
  :header-args:clojure:    :session *clojure-2*
  :END:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nikclayton/ob-sql-mode/16)
<!-- Reviewable:end -->
